### PR TITLE
Update NucleiFuzzer.sh

### DIFF
--- a/NucleiFuzzer.sh
+++ b/NucleiFuzzer.sh
@@ -70,17 +70,17 @@ fi
 
 # Step 3: Get the vulnerable parameters of the given domain name using ParamSpider tool and save the output into a text file
 echo "Running ParamSpider on $domain"
-python3 "$home_dir/ParamSpider/paramspider.py" -d "$domain" --exclude png,jpg,gif,jpeg,swf,woff,gif,svg --level high --quiet -o paramspider_output.txt
+python3 "$home_dir/ParamSpider/paramspider.py" -d "$domain" --exclude png,jpg,gif,jpeg,swf,woff,gif,svg --level high --quiet -o $domain-paramspider_output.txt
 
 # Check whether URLs were collected or not
-if [ ! -s output/paramspider_output.txt ]; then
+if [ ! -s output/$domain-paramspider_output.txt ]; then
     echo "No URLs Found. Exiting..."
     exit 1
 fi
 
-# Step 4: Run the Nuclei Fuzzing templates on paramspider_output.txt file
-echo "Running Nuclei on paramspider_output.txt"
-nuclei -l output/paramspider_output.txt -t "$home_dir/fuzzing-templates" -rl 05
+# Step 4: Run the Nuclei Fuzzing templates on <domain>-paramspider_output.txt file
+echo "Running Nuclei on $domain-paramspider_output.txt"
+nuclei -l output/$domain-paramspider_output.txt -t "$home_dir/fuzzing-templates" -rl 05
 
 # Step 5: End with general message as the scan is completed
 echo "Scan is completed - Happy Fuzzing"


### PR DESCRIPTION
This PR modifies the filename of the output file generated by ParamSpider from ``paramspider-output.txt`` to ``$domain-paramspider-output.txt``. This change enhances the functionality of the tool by allowing multiple scans to be run simultaneously and easily identifying which target is being scanned based on the output file name.

Currently, when running multiple scans using ParamSpider, it becomes challenging to determine which target each output file corresponds to. By incorporating the ``$domain`` variable in the output file name, it becomes more convenient to identify the specific target being scanned.